### PR TITLE
fixes deprecation warning

### DIFF
--- a/ui/Live.jsx
+++ b/ui/Live.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createContainer } from 'meteor/react-meteor-data';
+import { WithTracker } from 'meteor/react-meteor-data';
 import { Meteor } from 'meteor/meteor';
 
 import brace from 'brace';
@@ -175,8 +175,8 @@ class Live extends React.Component {
     }
 }
 
-export default createContainer(() => {
+export default withTracker(() => {
     return {
         user: Meteor.user ? Meteor.user() : null
     }
-}, Live)
+})(Live)


### PR DESCRIPTION
```
Warning: createContainer was deprecated in react-meteor-data@0.2.13. Use withTracker instead.
https://github.com/meteor/react-packages/tree/devel/packages/react-meteor-data#usage
```